### PR TITLE
Update the Gateway's dockerhub repository

### DIFF
--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -3,7 +3,7 @@ services:
     gateway:
         ports:
             - 8080:8080
-        image: openfaas/gateway:0.11.0-arm64
+        image: dfquaresma/openfaas-gateway:latest-dev
         networks:
             - functions
         environment:

--- a/docker-compose.armhf.yml
+++ b/docker-compose.armhf.yml
@@ -3,7 +3,7 @@ services:
     gateway:
         ports:
             - 8080:8080
-        image: openfaas/gateway:0.12.0-armhf
+        image: dfquaresma/openfaas-gateway:latest-dev
         networks:
             - functions
         environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     gateway:
         ports:
             - 8080:8080
-        image: openfaas/gateway:0.12.0
+        image: dfquaresma/openfaas-gateway:latest-dev
         networks:
             - functions
         environment:

--- a/gateway/build.sh
+++ b/gateway/build.sh
@@ -24,9 +24,9 @@ if [ "$1" ] ; then
   fi
 fi
 
-NS=openfaas
+NS=dfquaresma
 
-echo Building $NS/gateway:$eTAG
+echo Building $NS/openfaas-gateway:$eTAG
 
 GIT_COMMIT_MESSAGE=$(git log -1 --pretty=%B 2>&1 | head -n 1)
 GIT_COMMIT_SHA=$(git rev-list -1 HEAD)
@@ -35,4 +35,4 @@ VERSION=$(git describe --all --exact-match `git rev-parse HEAD` | grep tags | se
 docker build --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy \
   --build-arg GIT_COMMIT_MESSAGE="$GIT_COMMIT_MESSAGE" --build-arg GIT_COMMIT_SHA=$GIT_COMMIT_SHA \
   --build-arg VERSION=${VERSION:-dev} \
-  -t $NS/gateway:$eTAG . -f $dockerfile --no-cache
+  -t $NS/openfaas-gateway:$eTAG . -f $dockerfile --no-cache

--- a/gateway/push.sh
+++ b/gateway/push.sh
@@ -21,7 +21,6 @@ if [ "$1" ] ; then
   fi
 fi
 
-echo Pushing openfaas/gateway:$eTAG
+echo Pushing dfquaresma/openfaas-gateway:$eTAG
 
-docker push openfaas/gateway:$eTAG
-
+docker push dfquaresma/openfaas-gateway:$eTAG


### PR DESCRIPTION
This PR updates the Dockerhub repository to where Gateway's built images must be sent. It also updates the faas's docker compose file to use the new repository. 