### PR TITLE
Update faas-swarm reference

### DIFF
--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -43,7 +43,7 @@ services:
     faas-swarm:
         volumes:
             - "/var/run/docker.sock:/var/run/docker.sock"
-        image:  openfaas/faas-swarm:0.6.1-arm64
+        image:  dfquaresma/openfaas-faas-swarm:latest-dev
         networks:
             - functions
         environment:

--- a/docker-compose.armhf.yml
+++ b/docker-compose.armhf.yml
@@ -43,7 +43,7 @@ services:
     faas-swarm:
         volumes:
             - "/var/run/docker.sock:/var/run/docker.sock"
-        image:  openfaas/faas-swarm:0.6.1-armhf
+        image:  dfquaresma/openfaas-faas-swarm:latest-dev
         networks:
             - functions
         environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     faas-swarm:
         volumes:
             - "/var/run/docker.sock:/var/run/docker.sock"
-        image: openfaas/faas-swarm:0.6.1
+        image: dfquaresma/openfaas-faas-swarm:latest-dev
         networks:
             - functions
         environment:


### PR DESCRIPTION
This PR updates the Dockerhub's reference of faas-swarm from openfaas repository to dfquaresma.